### PR TITLE
chore: Setup CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2.1
+
+orbs:
+  rails: planningcenter/rails@2.2.0
+
+jobs:
+  build:
+    executor:
+      name: rails/default
+      ruby-version: "2.7"
+    steps:
+      - checkout
+      - rails/bundle
+      - rails/yarn
+      - rails/precompile-assets
+
+workflows:
+  default:
+    jobs:
+      - build:
+          context:
+            - GitHub Packages
+            - AWS ECR (circleci-tools)

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.7.4"
-
 gem "rails", "~> 5.2.7"
 gem "sqlite3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,8 +260,5 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webpacker
 
-RUBY VERSION
-   ruby 2.7.4p191
-
 BUNDLED WITH
    2.3.11


### PR DESCRIPTION
### Background

This repo was broken, but it went unnoticed until recently.

### Changes

I've added a minimal Circle config that's more of a build check than anything, but it does most of what the readme says to do: install dependencies and compile assets.

### Value

This provides a small safety net to help us see certain issues sooner than later and keep the process as smooth as possible.

I created this branch off of `main` when the issue was present. You can see CI failing when it's added, and the build passes once I merged in `main` which included the fix from #11.